### PR TITLE
Make the source distribution installable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,10 @@ from distutils.util import convert_path
 from setuptools import setup, find_packages
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    try:
+        return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    except IOError:
+        return ""
 
 # Provided as an attribute, so you can append to these instead
 # of replicating them:


### PR DESCRIPTION
Currently the source distribution going to the PyPI doesn't include the README.md, but the call to setup() requires it to be adjacent to the setup.py file. This means the version of this library in PyPI is not installable.

This patch makes the read() function return an empty string if it can't open the README.md. This means the PKG-INFO will still have the readme info, but the package can install without the README.

There may be another way to handle this with the find_package_data function to include the README.md in the source distribution, so it can be included properly.
