### PR TITLE
clean_<feild> doesn't appear when using decorator

### DIFF
--- a/parsley/decorators.py
+++ b/parsley/decorators.py
@@ -29,6 +29,5 @@ def parsleyfy(klass):
     ParsleyClass.__doc__ = klass.__doc__
     ParsleyClass.__module__ = klass.__module__
     ParsleyClass.__name__ = klass.__name__
-    ParsleyClass.__bases__ = klass.__bases__
 
     return ParsleyClass


### PR DESCRIPTION
I faced issue on this form:
http://pastebin.com/Tca78SQ5
but it doesn't call the clean_confirm_password.
modified:   parsley/decorators.py
