### PR TITLE
Move README file to reStructuredText

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,29 +1,39 @@
 django-parsley
-------------------------
+==============
 
-[![Build Status](https://travis-ci.org/agiliq/Django-parsley.png?branch=master)](https://travis-ci.org/agiliq/Django-parsley)
-[![Coverage Status](https://coveralls.io/repos/agiliq/Django-parsley/badge.png?branch=master)](https://coveralls.io/r/agiliq/Django-parsley)
+.. image:: https://travis-ci.org/agiliq/Django-parsley.png?branch=master
+   :target: https://travis-ci.org/agiliq/Django-parsley
+   :alt: Build Status
 
-###What is it?
+.. image:: https://coveralls.io/repos/agiliq/Django-parsley/badge.png?branch=master
+   :target: https://coveralls.io/r/agiliq/Django-parsley
+   :alt: Coverage Status
 
-[Parsleyjs](http://parsleyjs.org/) is a JavaScript library to do client side data validations.
-It does this in a non-intrusive way via adding a `data-*` attributes to form fields.
+What is it?
+-----------
+
+`Parsleyjs`_ is a JavaScript library to do client side data validations.
+It does this in a non-intrusive way via adding a ``data-*`` attributes to form fields.
 
 When you define a Django form, you get server side validations for free using
-the form field attributes. Django-parsley adds these validations to client side, by tagging your form with `data-*` attributes.
+the form field attributes. Django-parsley adds these validations to client side, by tagging your form with ``data-*`` attributes.
 
-Parsley plays well with `crispy-forms` et all.
+Parsley plays well with ``crispy-forms`` et all.
 
-### Installation
+Installation
+------------
 
-1. pip install `parsley` (or add to your requirements.txt)
-2. add `parsley` to your `INSTALLED_APPS` (required for static files added by mixin)
+1. pip install ``parsley`` (or add to your requirements.txt)
+2. add ``parsley`` to your ``INSTALLED_APPS`` (required for static files added by mixin)
 
-### Usage
+Usage
+-----
 
-`parsley` provides a single class decorator called `parsleyfy`. Decorate your `Form` with `parsleyfy` to get the validations.
+``parsley`` provides a single class decorator called ``parsleyfy``. Decorate your ``Form`` with ``parsleyfy`` to get the validations.
 
 Eg.
+
+.. code-block:: python
 
     from parsley.decorators import parsleyfy
 
@@ -40,6 +50,8 @@ Eg.
 
 Your rendered form's HTML will look like this
 
+.. code-block:: html
+
     <p><label for="id_name">Name:</label> <input data-required="true" data-minlength="3" maxlength="30" type="text" data-maxlength="30" id="id_name" name="name" /></p>
     <p><label for="id_url">Url:</label> <input type="text" data-required="true" data-type="url" name="url" id="id_url" /></p>
     <p><label for="id_url2">Url2:</label> <input type="text" data-type="url" name="url2" id="id_url2" /></p>
@@ -48,15 +60,19 @@ Your rendered form's HTML will look like this
     <p><label for="id_age">Age:</label> <input type="text" data-required="true" data-type="digits" name="age" id="id_age" /></p>
     <p><label for="id_income">Income:</label> <input type="text" data-required="true" data-type="number" name="income" id="id_income" /></p>
 
-Note the `data-*` attributes.
+Note the ``data-*`` attributes.
 
 You could also do
+
+.. code-block:: python
 
     FieldTypeForm = parsleyfy(FieldTypeForm)
 
 Which is the same thing.
 
 Put this form inside a
+
+.. code-block:: html
 
     <form data-validate="parsley">
         {{ form.as_p }}
@@ -65,20 +81,26 @@ Put this form inside a
 Include the parsleyjs and you are good to go.
 
 
-### Admin
+Admin
+-----
 
-To add parsley validations to admin, use the `ParsleyAdminMixin` with your `ModelAdmin` like so:
+To add parsley validations to admin, use the ``ParsleyAdminMixin`` with your ``ModelAdmin`` like so:
+
+.. code-block:: python
 
     class StudentAdmin(ParsleyAdminMixin, admin.ModelAdmin):
         pass
 
-Note that the above mixin adds two scripts: `parsley-standalone.min.js` and `parsley.django-admin.js` to the admin media.
+Note that the above mixin adds two scripts: ``parsley-standalone.min.js`` and ``parsley.django-admin.js`` to the admin media.
 
-### Advanced Usage
+Advanced Usage
+--------------
 
 In addition to the default validators if you want to add extra client side validations
-or if you want to add custom validators, add a `parsley_extras` Meta attribute. For e.g
-if you wanted to add `minlength` and `equalto` validations on a `PasswordChangeForm`:
+or if you want to add custom validators, add a ``parsley_extras`` Meta attribute. For e.g
+if you wanted to add ``minlength`` and ``equalto`` validations on a ``PasswordChangeForm``:
+
+.. code-block:: python
 
     @parsleyfy
     class PasswordChangeForm(BasePasswordChangeForm):
@@ -93,10 +115,15 @@ if you wanted to add `minlength` and `equalto` validations on a `PasswordChangeF
                 },
             }
 
-###License
+License
+-------
 
 3 Clause BSD.
 
-### Bug report and Help
+Bug report and Help
+-------------------
 
-For bug reports open a github ticket. Patches gratefully accepted. Need help? [Contact us here](http://agiliq.com/contactus)
+For bug reports open a github ticket. Patches gratefully accepted. Need help? `Contact us here`_
+
+.. _parsleyjs: http://parsleyjs.org/
+.. _contact us here: http://agiliq.com/contactus


### PR DESCRIPTION
The PyPI page is difficult to read because PyPI doesn't understand markdown:
![selection_067](https://f.cloud.github.com/assets/285352/1151478/923a48fa-1efb-11e3-8acd-eaeed8220d4e.png)

The README file could also benefit from syntax highlighting (which works on Github and PyPI).

Before (no syntax highlighting):
![selection_068](https://f.cloud.github.com/assets/285352/1151491/b4718334-1efb-11e3-86ec-979efc668215.png)

After (syntax highlighting):
![selection_069](https://f.cloud.github.com/assets/285352/1151500/c31c0850-1efb-11e3-9138-0b4092249f19.png)

As you can see from the diff, rST isn't more difficult to read than markdown.
