### PR TITLE
Do not force a specific jQuery version.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ Put this form inside a
         {{ form.as_p }}
     </form>
 
-.. note::  The decorator adds ``jquery`` and ``parsley.min.js`` to form media
+.. note:: Make sure `jquery.js` and `parsley.js` are included in the template.
 
 Admin
 -----
@@ -113,7 +113,7 @@ To add parsley validations to admin, use the ``ParsleyAdminMixin`` with your ``M
     class StudentAdmin(ParsleyAdminMixin, admin.ModelAdmin):
         pass
 
-.. note:: The mixin adds an additional script: ``parsley.django-admin.js`` to the admin media.
+.. note:: Use the `parsley.django-admin.js` helper from parsley static to auto-validate admin forms.
 
 Advanced Usage
 --------------

--- a/example/core/admin.py
+++ b/example/core/admin.py
@@ -7,7 +7,13 @@ from parsley.mixins import ParsleyAdminMixin
 
 
 class MyUserAdmin(ParsleyAdminMixin, UserAdmin):
-    pass
+
+    class Media:
+        js = (
+            "//code.jquery.com/jquery-latest.min.js",
+            "parsley/js/parsley.min.js",
+            "parsley/js/parsley.django-admin.js"
+        )
 
 
 admin.site.unregister(User)

--- a/example/core/templates/home.html
+++ b/example/core/templates/home.html
@@ -27,6 +27,7 @@
             */
         </style>
         <script src="http://code.jquery.com/jquery-1.10.1.min.js" ></script>
+        <script src="{{ STATIC_URL }}parsley/js/parsley.js" ></script>
         <script type='text/javascript' src='{{ STATIC_URL }}core/js/bootstrap-tab.min.js'></script>
         {{ form.media }}
 

--- a/parsley/decorators.py
+++ b/parsley/decorators.py
@@ -84,15 +84,4 @@ def parsleyfy(klass):
                 attrs["{prefix}-%s".format(prefix=prefix) % key] = value
     klass.__init__ = new_init
 
-    js_media = (
-        "//code.jquery.com/jquery-latest.min.js",
-        "parsley/js/parsley.min.js",
-    )
-    try:
-        klass.Media.js += js_media
-    except AttributeError:
-        class Media:
-            js = js_media
-        klass.Media = Media
-
     return klass

--- a/parsley/mixins.py
+++ b/parsley/mixins.py
@@ -6,11 +6,3 @@ class ParsleyAdminMixin(object):
     def get_form(self, *args, **kwargs):
         form = super(ParsleyAdminMixin, self).get_form(*args, **kwargs)
         return parsleyfy(form)
-
-    class Media:
-        extend = False
-        js = (
-            "//code.jquery.com/jquery-latest.min.js",
-            "parsley/js/parsley.min.js",
-            "parsley/js/parsley.django-admin.js",
-        )

--- a/parsley/tests/tests.py
+++ b/parsley/tests/tests.py
@@ -205,43 +205,6 @@ class TestExtraAttributes(ParsleyTestCase):
         ExtraDataMissingFieldForm()  # No error should be raised
 
 
-class TestAdminMixin(ParsleyTestCase):
-    def test_media(self):
-        student_admin = StudentAdmin(Student, admin.site)
-        js = student_admin.media.render_js()
-        self.assertIn(
-            '<script type="text/javascript" src="/static/parsley/js/parsley.min.js"></script>',
-            js
-        )
-        self.assertIn(
-            '<script type="text/javascript" src="/static/parsley/js/parsley.django-admin.js"></script>',
-            js
-        )
-
-
-class TestFormMedia(ParsleyTestCase):
-
-    def test_form_media(self):
-        form = FormWithoutMedia()
-        js = form.media.render_js()
-        self.assertIn(
-            '<script type="text/javascript" src="/static/parsley/js/parsley.min.js"></script>',
-            js
-        )
-
-    def test_existing_form_media(self):
-        form = FormWithMedia()
-        js = form.media.render_js()
-        self.assertIn(
-            '<script type="text/javascript" src="/static/jquery.min.js"></script>',
-            js
-        )
-        self.assertIn(
-            '<script type="text/javascript" src="/static/parsley/js/parsley.min.js"></script>',
-            js
-        )
-
-
 class TestMultiValueField(ParsleyTestCase):
     def test_parsley_attributes(self):
         form = MultiWidgetForm()


### PR DESCRIPTION
Let users include their own version of jQuery as they see fit. Using the `jquery-latest` URL is not recommended, either (no pinned version, can't send good cache headers).

Additionally, there's no need to include jQuery in the Admin mixin as jQuery's already included there.
