### PR TITLE
removed django and six as dependency as this is django-parsley its a giv...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
         "Framework :: Django",
     ],
     zip_safe=False,
-    install_requires=["Django"],
-    tests_require=["Django", "six"],
+    install_requires=[],
+    tests_require=[],
     test_suite='runtests.runtests',
 )


### PR DESCRIPTION
removed django and six as dependency as this is django-parsley.. "django" is a given.

A bug is that installing in production will overwrite current django versions.

This is very bad behaviour
