### PR TITLE
Note Python 3 support in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
         "Framework :: Django",
     ],
     zip_safe=False,


### PR DESCRIPTION
caniusepython3 informed me that django-parsley doesn't support it.  Python 3 is supported by tests in the tox file so I added a Python 3 classifier trove to note the support.
