### PR TITLE
Allow Django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ env:
   - DJANGO='Django>=1.4,<1.5'
   - DJANGO='Django>=1.5,<1.6'
   - DJANGO='Django>=1.6,<1.7'
-#  - DJANGO='Django>=1.7,<1.8'
+  - DJANGO='Django>=1.7,<1.8'
+  - DJANGO='Django>=1.8,<1.9'
 #  - DJANGO='https://github.com/django/django/tarball/stable/1.8.x'
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
         "Framework :: Django",
     ],
     zip_safe=False,
-    install_requires=["Django>=1.3,<=1.8"],
+    install_requires=["Django>=1.3,<=1.8.999"],
     tests_require=["Django>=1.3,<=1.7", "six"],
     test_suite='runtests.runtests',
 )


### PR DESCRIPTION
I created my fork to get this to install with Django 1.8. I've tested a few things and it all seems to *just work™*.

Also be careful with your dependency definitions. <=1.8 will allow 1.8 but not a point release like 1.8.2. If you meant <1.8 (eg up to any 1.7.* release) I've read (citation needed) you should use a syntax like <=1.7.999 instead as it's safer. It's certainly easier to understand.