### PR TITLE
Fixes https://github.com/agiliq/Django-parsley/issues/63

### DIFF
--- a/parsley/tests/tests.py
+++ b/parsley/tests/tests.py
@@ -163,14 +163,14 @@ class TestRadioSelect(ParsleyTestCase):
         self.assertEqual(form.fields['state'].choices,
                     [("NY", "NY"), ("OH", "OH")])
         radio_select_html = form.fields['state'].widget.render("state", "NY")
-        self.assertEqual(1, len(re.findall('data-parsley-mincheck', radio_select_html)))
+        self.assertEqual(1, len(re.findall('data-parsley-required', radio_select_html)))
 
     def test_radio_select_not_required(self):
         form = FormWithRadioSelectNotRequired()
         self.assertEqual(form.fields['state'].choices,
                     [("NY", "NY"), ("OH", "OH")])
         radio_select_html = form.fields['state'].widget.render("state", "NY")
-        self.assertEqual(0, len(re.findall('data-parsley-mincheck', radio_select_html)))
+        self.assertEqual(0, len(re.findall('data-parsley-required', radio_select_html)))
 
 
 class TestCleanFields(ParsleyTestCase):

--- a/parsley/widgets.py
+++ b/parsley/widgets.py
@@ -6,5 +6,5 @@ class ParsleyChoiceFieldRendererMixin(object):
     def __getitem__(self, idx):
         choice = self.choices[idx]
         if idx == len(self.choices) - 1:
-            self.attrs["{prefix}-mincheck".format(prefix=self.parsley_namespace)] = "1"
+            self.attrs["{prefix}-required".format(prefix=self.parsley_namespace)] = "true"
         return super(ParsleyChoiceFieldRendererMixin, self).__getitem__(idx)


### PR DESCRIPTION
required=True on RadioSelect wasn't being validated by parsley.js. data-parsley-mincheck has a different purpose from data-parsley-required. In our scenario we want data-parsley-required.

data-parsley-mincheck should be used when we want to validate that a
minimum number of radioboxes are checked. But data-parsley-mincheck
can't enforce required=True.