### PR TITLE
There is no need to add "errors" and "listeners" in django-admin.js

### DIFF
--- a/parsley/static/parsley/js/parsley.django-admin.js
+++ b/parsley/static/parsley/js/parsley.django-admin.js
@@ -8,21 +8,6 @@
   $( window ).on( 'load', function () {
     $( 'form' ).each( function () {
       $( this ).parsley({
-          animate: false,
-          errors: {
-              errorsWrapper: '<ul class="errorlist"></ul>',
-              container: function (element, isRadioOrCheckbox) {
-                  return $("<div />").prependTo(element.closest(".form-row"));
-              }
-          },
-          listeners: {
-              onFieldError: function (element) {
-                  var container = element.closest(".form-row");
-                  if (container.not(".errors")) {
-                      container.addClass("errors");
-                  }
-              }
-          }
       });
     } );
   } );


### PR DESCRIPTION
Probably these things while calling $(this).parsley() was required for old version of parsley.js, but isn't
required with current version of parsley.js.