### PR TITLE
Don't parsleyfy Django admin search boxes

### DIFF
--- a/parsley/static/parsley/js/parsley.django-admin.js
+++ b/parsley/static/parsley/js/parsley.django-admin.js
@@ -1,14 +1,13 @@
 /*
  * Parsley.js - django admin helper
-*/
+ */
+! function($) {
+    'use strict';
 
-!function ($) {
-  'use strict';
-
-  $( window ).on( 'load', function () {
-    $( 'form' ).each( function () {
-      $( this ).parsley({
-      });
-    } );
-  } );
+    $(window).on('load', function() {
+        // Don't parsleyfy Django search boxes. It breaks layout
+        $('form:not(#changelist-search, #changelist-form)').each(function() {
+            $(this).parsley({});
+        });
+    });
 }(window.jQuery || window.Zepto);


### PR DESCRIPTION
It prevents layout to break by not applying parsley auto-validate for search boxes.