### PR TITLE
Move parsley-errors-list after help elements

### DIFF
--- a/parsley/static/parsley/js/parsley.django-admin.js
+++ b/parsley/static/parsley/js/parsley.django-admin.js
@@ -9,5 +9,9 @@
         $('form:not(#changelist-search, #changelist-form)').each(function() {
             $(this).parsley({});
         });
+        // Move parsley-errors-list after help elements because it looks less broken.
+        $('.parsley-errors-list + .help').each(function() {
+            $(this).after($(this).prev());
+        });
     });
 }(window.jQuery || window.Zepto);


### PR DESCRIPTION
You might consider merging this pull request. It moves the parsley-errors-list elements behind Django admin's help elements. In complex forms I found it to look better (less broken) than the other way around.