### PR TITLE
Add support for Django 2.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py{27,34,35}-dj{18,19,110}
     py{27,34,35,36}-dj{111}
+    py{35,36,37}-dj{21}
 skipsdist = True
 
 
@@ -12,9 +13,11 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 deps =
     coverage>=4
     dj18: django==1.8.18
     dj19: django==1.9.13
     dj110: django==1.10.7
     dj111: django==1.11.1
+    dj21: django>=2.1,<2.2


### PR DESCRIPTION
Add django 2.1 to `tox.ini`. Tests pass without any changes.
Skipped 2.0 as it is already EOL.